### PR TITLE
Structurize project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .venv
+*.egg-info/
 __pycache__

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "banking_machine"
 version = "0.1.0"
 readme = "README.md"
-requires-python = ">=3.12"
+requires-python = ">=3.13"
 description = "Small libary to simulate a banking mashine with a gui"
 authors = [{ name = "Paul Jonas Dohle", email = "paul.jonas@dohle-net.de" }]
 license = { file = "LICENSE" }
@@ -11,7 +11,7 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Intended Audience :: Education",
     "Intended Audience :: Developers",
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,4 +18,6 @@ classifiers = [
 ]
 
 [project.urls]
-# TODO Add after hosting on GitHub
+Repository = "https://github.com/RedLion8399/banking_machine"
+Issues = "https://github.com/RedLion8399/banking_machine/issues"
+Documentation = "https://github.com/RedLion8399/banking_machine/issues"


### PR DESCRIPTION
- Add reference links in documentation to repo, issues, and online-docs / wiki
- Change Python version to latest 3.13
For any reason th global python installation broke and .venv as well which required a new installation of python. Because no real code existed in that moment choosing the latest version for the new .venv was possible and safes later maybe a bit of work.